### PR TITLE
src/modemu2k.h:include sys/time.h

### DIFF
--- a/src/modemu2k.h
+++ b/src/modemu2k.h
@@ -33,6 +33,7 @@
 #include <string.h>             /*(strncpy) */
 #include <stdbool.h>
 #include <sys/types.h>
+#include <sys/time.h>
 
 #ifdef TERMNET
 #include <termnet.h>

--- a/src/sock.c
+++ b/src/sock.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2018-2019 Andy Alt <andy400-dev@yahoo.com>
+ * Copyright 2018-2022 Andy Alt <arch_stanton5995@protonmail.com>
  *
  * modemu2k is a fork of modemu
  * Originally developed by Toru Egashira
@@ -27,7 +27,7 @@
 #include <errno.h>
 #include <netdb.h>
 #include <unistd.h>
-#include <sys/time.h>   /*->ttybuf.h (timeval)*/
+// #include <sys/time.h>   /*->ttybuf.h (timeval)*/
 #include <stdlib.h>             /*(getenv) */
 #include "modemu2k.h"
 


### PR DESCRIPTION
Trying to fix

```
 In file included from ../src/sockbuf.c:4:
../src/modemu2k.h:309:29: warning: declaration of 'struct timeval' will
not be visible outside of this function [-Wvisibility]
void timevalSet10ms (struct timeval *ap, int b);
                            ^
../src/modemu2k.h:310:25: warning: declaration of 'struct timeval' will
not be visible outside of this function [-Wvisibility]
void timevalAdd (struct timeval *ap, const struct timeval *bp);
                        ^
../src/modemu2k.h:311:25: warning: declaration of 'struct timeval' will
not be visible outside of this function [-Wvisibility]
void timevalSub (struct timeval *ap, const struct timeval *bp);
                        ^
../src/modemu2k.h:312:30: warning: declaration of 'struct timeval' will
not be visible outside of this function [-Wvisibility]
int timevalCmp (const struct timeval *ap, const struct timeval *bp);
                             ^
../src/modemu2k.h:332:18: error: field has incomplete type 'struct
timeval'
  struct timeval newT;
                 ^
../src/modemu2k.h:332:10: note: forward declaration of 'struct timeval'
  struct timeval newT;
         ^
../src/modemu2k.h:333:18: error: field has incomplete type 'struct
timeval'
  struct timeval prevT;
                 ^
../src/modemu2k.h:332:10: note: forward declaration of 'struct timeval'
  struct timeval newT;
         ^
4 warnings and 2 errors generated.
```