### PR TITLE
ci: add BSD workflow for FreeBSD and OpenBSD

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -1,0 +1,46 @@
+name: BSD
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ master ]
+    paths: &shared_paths
+      - '**'
+      - '!**.yml'
+      - '!**.md'
+      - '**/bsd.yml'
+
+  pull_request:
+    branches: [ master ]
+    paths: *shared_paths
+
+jobs:
+  BSD:
+    name: ${{ matrix.os }} ${{ matrix.version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: freebsd
+            version: '15.0'
+            install: sudo pkg install -y flex meson ninja pkgconf
+          - os: openbsd
+            version: '7.8'
+            install: sudo pkg_add flex meson ninja pkgconf
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Test
+      uses: cross-platform-actions/action@v1
+      with:
+        operating_system: ${{ matrix.os }}
+        version: ${{ matrix.version }}
+        run: |
+          ${{ matrix.install }}
+          CFLAGS="-Werror" meson setup _build
+          meson compile -C _build
+          meson test --no-stdsplit -v -C _build
+          meson install --destdir=install_test -C _build


### PR DESCRIPTION
Runs meson build, tests, and install check on FreeBSD 15.0 and OpenBSD 7.8 via cross-platform-actions.