### PR TITLE
feat: print usage hint when invoked with no arguments

### DIFF
--- a/man/modemu2k.1
+++ b/man/modemu2k.1
@@ -24,13 +24,26 @@ so that a comm program can handle the pty as a tty with a real modem.
 .PP
 .B Modemu2k
 has two major modes: a command mode and online mode.
-When invoked,
+Invoked with at least one option (e.g.\&
+.BR -c ,
+.BR -d ,
+.BR -e ,
+or
+.BR -l ),
 .B modemu2k
-is in the command mode, waiting for AT commands input.
+starts in command mode, waiting for AT commands input.
 Entering a D or O command will put into the online mode, in which \" <===
 .B modemu2k
 communicate with a remote host.
 Connection closing or a escape command input returns to the command mode.
+.PP
+Invoked with no arguments,
+.B modemu2k
+prints a short usage hint and exits without entering command mode.
+Use
+.B -e
+to reach standalone command mode on stdin/stdout (for example,
+.IR "modemu2k -e AT" ).
 .\"
 .\"
 .SH OPTIONS

--- a/src/cmdarg.c
+++ b/src/cmdarg.c
@@ -46,7 +46,8 @@ showUsage(char *const argv[])
   puts("\
   -d, --device=<pty_master>               talk through [pty_master]");
   puts("\
-  -e, --atstring=\"<ATxxx>\"                execute [ATxxx] commands at startup");
+  -e, --atstring=\"<ATxxx>\"                execute [ATxxx] commands at startup,\n\
+                                          then read AT commands interactively from stdin");
   puts("\
   -l, --listen=<port>                     listen for an incoming TCP connection on [port]");
   puts("\

--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,22 @@ main(int argc, char *const argv[])
   SOCKSinit(argv[0]);
 #endif
 
+  if (argc == 1)
+  {
+    fputs(
+      "modemu2k is a PTY-based modem emulator that bridges a comm program to TCP/Telnet.\n"
+      "\n"
+      "Usage with minicom:\n"
+      "  modemu2k -c \"minicom -l -tansi -con -p %s\"\n"
+      "\n"
+      "Usage with picocom:\n"
+      "  modemu2k -c \"picocom %s\"\n"
+      "\n"
+      "Run 'modemu2k --help' for full options.\n",
+      stdout);
+    return 0;
+  }
+
   m2k_t *ctx = m2k_new();
   if (ctx == NULL)
     return EXIT_FAILURE;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -26,11 +26,27 @@ endforeach
 
 python3 = find_program('python3', required: false)
 if python3.found()
+  py_test_cases = {
+    'listen_integration': 'test_listen_integration.py',
+    'dial_integration':   'test_dial_integration.py',
+  }
+  foreach case, script : py_test_cases
+    test(
+      'test_' + case,
+      python3,
+      args: [files(script), modemu2k_exe.full_path()],
+      depends: modemu2k_exe,
+      timeout: 30,
+      )
+  endforeach
+endif
+
+sh = find_program('sh', required: false)
+if sh.found()
   test(
-    'test_listen_integration',
-    python3,
-    args: [files('test_listen_integration.py'), modemu2k_exe.full_path()],
+    'test_no_arg_usage',
+    sh,
+    args: [files('test_no_arg_usage.sh'), modemu2k_exe.full_path()],
     depends: modemu2k_exe,
-    timeout: 30,
     )
 endif

--- a/tests/test_dial_integration.py
+++ b/tests/test_dial_integration.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Dial-mode integration test for modemu2k.
+
+Launches modemu2k in CA_STDINOUT mode (entered via `-e "ATZ"`, the
+minimum flag needed past the new no-arg usage hint), drives an
+AT-command sequence through stdin/stdout, and verifies the
+dial -> data -> disconnect -> exit lifecycle against a local
+Python TCP server.
+
+Usage: test_dial_integration.py <path-to-modemu2k>
+"""
+import os
+import select
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+
+def strip_iac(buf):
+    """Remove telnet IAC sequences so plain data bytes can be echoed safely."""
+    out = bytearray()
+    i = 0
+    while i < len(buf):
+        b = buf[i]
+        if b != 0xFF:
+            out.append(b)
+            i += 1
+            continue
+        if i + 1 >= len(buf):
+            break
+        cmd = buf[i + 1]
+        if cmd in (0xFB, 0xFC, 0xFD, 0xFE):    # WILL/WONT/DO/DONT: 3-byte
+            i += 3
+        elif cmd == 0xFA:                       # SB ... IAC SE
+            j = i + 2
+            while j + 1 < len(buf) and not (buf[j] == 0xFF and buf[j + 1] == 0xF0):
+                j += 1
+            i = j + 2
+        else:                                   # 2-byte command
+            i += 2
+    return bytes(out)
+
+
+class EchoServer:
+    def __init__(self):
+        self.sock = socket.socket()
+        self.sock.bind(("127.0.0.1", 0))
+        self.sock.listen(1)
+        self.port = self.sock.getsockname()[1]
+        self.conn = None
+        self._stop = threading.Event()
+        self.thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self):
+        self.thread.start()
+
+    def _run(self):
+        self.sock.settimeout(5.0)
+        try:
+            self.conn, _ = self.sock.accept()
+        except socket.timeout:
+            return
+        self.conn.settimeout(0.2)
+        while not self._stop.is_set():
+            try:
+                data = self.conn.recv(4096)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            if not data:
+                break
+            payload = strip_iac(data)
+            if payload:
+                try:
+                    self.conn.sendall(payload)
+                except OSError:
+                    break
+        try:
+            self.conn.close()
+        except OSError:
+            pass
+
+    def disconnect_client(self):
+        self._stop.set()
+        try:
+            if self.conn:
+                self.conn.shutdown(socket.SHUT_RDWR)
+                self.conn.close()
+        except OSError:
+            pass
+
+    def shutdown(self):
+        self._stop.set()
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+
+def read_until(stream, needle, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    buf = bytearray()
+    while time.monotonic() < deadline:
+        r, _, _ = select.select([stream], [], [], 0.1)
+        if r:
+            chunk = os.read(stream.fileno(), 4096)
+            if not chunk:
+                break
+            buf += chunk
+            if needle in buf:
+                return bytes(buf)
+    return bytes(buf)
+
+
+def fail(msg, captured=b""):
+    sys.stderr.write(f"FAIL: {msg}\n")
+    if captured:
+        sys.stderr.write(f"  captured: {captured!r}\n")
+    return 1
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: test_dial_integration.py <modemu2k-binary>", file=sys.stderr)
+        return 2
+    binary = sys.argv[1]
+
+    server = EchoServer()
+    server.start()
+
+    proc = subprocess.Popen(
+        [binary, "-e", "ATZ"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=0,
+    )
+
+    def send(s):
+        proc.stdin.write(s.encode())
+
+    try:
+        send("AT\r")
+        out = read_until(proc.stdout, b"OK")
+        if b"OK" not in out:
+            return fail("no OK to bare AT", out)
+
+        send(f"ATD127.0.0.1 {server.port}\r")
+        out = read_until(proc.stdout, b"CONNECT")
+        if b"CONNECT" not in out:
+            return fail("no CONNECT after dial", out)
+
+        send("ping\n")
+        out = read_until(proc.stdout, b"ping", timeout=3.0)
+        if b"ping" not in out:
+            return fail("data did not round-trip through online loop", out)
+
+        server.disconnect_client()
+        out = read_until(proc.stdout, b"NO CARRIER", timeout=3.0)
+        if b"NO CARRIER" not in out:
+            return fail("no NO CARRIER after server disconnect", out)
+
+        proc.stdin.close()
+        try:
+            rc = proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            return fail("modemu2k did not exit on stdin EOF")
+        if rc != 0:
+            return fail(f"modemu2k exited with status {rc}")
+        return 0
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_listen_integration.py
+++ b/tests/test_listen_integration.py
@@ -14,13 +14,10 @@ import subprocess
 import sys
 import time
 
-
-def pick_free_port():
-    s = socket.socket()
-    s.bind(("127.0.0.1", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
+# Fixed port to avoid the bind-race between the test's port picker and
+# modemu2k's listen(). The unit tests use 19876 (IPv4) and 19877 (IPv6);
+# the integration test reserves the next slot in that range.
+TEST_PORT = 19878
 
 
 def connect_with_retry(port, timeout=5.0):
@@ -59,7 +56,7 @@ def main():
         print(f"FAIL: {binary} is not executable", file=sys.stderr)
         return 1
 
-    port = pick_free_port()
+    port = TEST_PORT
     proc = subprocess.Popen(
         [binary, "-l", str(port)],
         stdin=subprocess.DEVNULL,

--- a/tests/test_no_arg_usage.sh
+++ b/tests/test_no_arg_usage.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Verify the no-argument startup hint.
+#
+# Usage: test_no_arg_usage.sh <modemu2k-binary>
+set -e
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <modemu2k-binary>" >&2
+  exit 2
+fi
+
+bin="$1"
+out=$("$bin")
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  echo "FAIL: expected exit 0, got $rc" >&2
+  exit 1
+fi
+
+case "$out" in
+  *"Run 'modemu2k --help' for full options."*) ;;
+  *)
+    echo "FAIL: expected --help hint in stdout, got:" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Previously `modemu2k` (no args) dropped the user into the CA_STDINOUT AT-command session — surprising for first-time users who expected a help screen. Now `argc == 1` prints a short usage hint and exits 0, matching the agreed message in CLAUDE.md. CA_STDINOUT remains reachable via any flag (typically `-e <atstring>`), and the existing m2k-minicom script is unaffected since it always invokes modemu2k with arguments.

Also:
* Reword `-e/--atstring` help to advertise it as the way to reach the interactive AT session.
* Add tests/test_no_arg_usage.sh: shell test asserting exit 0 + hint.
* Add tests/test_dial_integration.py: end-to-end test of CA_STDINOUT driving ATD against a local Python TCP server, exercising the AT parser, m2k_sockDial, online-mode select() loop, NO CARRIER on remote close, and clean exit on stdin EOF.
* Refactor python tests into a meson dict loop for future per-test config; switch test_listen_integration to a fixed port (19878, slotting in after the C unit tests' 19876/19877) to close the bind-race window when running in parallel.